### PR TITLE
Task: Encode nested objects without fields key

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -54,9 +54,14 @@ describe('graphqlify', function () {
     expect(out).to.equal('{a(b:["c","d"])}');
   });
 
-  it('should encode a field with params and nested fields', function () {
+  it('should encode a field with params and fields', function () {
     const out = graphqlify({a: {params: {b: 'c'}, fields: {d: 1}}});
     expect(out).to.equal('{a(b:"c"){d}}');
+  });
+
+  it('should encode a field with params and nested fields', function () {
+    const out = graphqlify({a: {params: {b: 'c'}, fields: {d: {e: 1}}}});
+    expect(out).to.equal('{a(b:"c"){d{e}}}');
   });
 
   it('should encode a field with a fragment', function () {


### PR DESCRIPTION
instead of defining fields key for all sub-documents,
use the sub-document directly